### PR TITLE
Refactor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,6 @@
 #![cfg_attr(feature="clippy", deny(clippy, clippy_pedantic))]
 #![cfg_attr(feature="clippy", allow(use_debug))]
 
-extern crate memmap;
 extern crate rustc_serialize;
 
 mod error;
@@ -51,4 +50,4 @@ mod file_handler;
 
 pub use error::Error;
 pub use file_handler::{FileHandler, ScopedUserAppDirRemover, current_bin_dir, user_app_dir,
-                       system_cache_dir, exe_file_stem};
+                       system_cache_dir, exe_file_stem, cleanup};


### PR DESCRIPTION
Make the encoded type an argument to `FileHandler`
Make `FileHandler::new` initialise new files with the default value.
Add `FileHandler::open` method that fails if the file doesn't exist.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/config_file_handler/9)

<!-- Reviewable:end -->
