### PR TITLE
fix/all: always unlock the file, even on errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ repository = "https://github.com/maidsafe/config_file_handler"
 version = "0.3.1"
 
 [dependencies]
-fs2 = "~0.2.3"
+fs2 = "~0.2.5"
 quick-error = "~1.1.0"
-rustc-serialize = "~0.3.18"
+rustc-serialize = "~0.3.19"
 
 [dependencies.clippy]
 optional = true
-version = "~0.0.55"
+version = "~0.0.77"

--- a/src/file_handler.rs
+++ b/src/file_handler.rs
@@ -21,7 +21,7 @@ use rustc_serialize::json::{self, Json, Decoder};
 use std::env;
 use std::ffi::{OsStr, OsString};
 use std::fs::{self, OpenOptions};
-use std::io::{self, Write, Read};
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::marker::PhantomData;
 
@@ -54,7 +54,9 @@ impl<T> FileHandler<T> {
     /// process-safety.
     pub fn open<S: AsRef<OsStr> + ?Sized>(name: &S) -> Result<FileHandler<T>, Error> {
         let name = name.as_ref();
-        if let Ok(mut path) = current_bin_dir().or(user_app_dir()).or(system_cache_dir()) {
+        if let Ok(mut path) = current_bin_dir()
+            .or_else(|_| user_app_dir())
+            .or_else(|_| system_cache_dir()) {
             path.push(name);
             if let Ok(_) = OpenOptions::new().create(false).write(true).open(&path) {
                 return Ok(FileHandler {
@@ -95,7 +97,9 @@ impl<T> FileHandler<T>
 
         let contents = format!("{}", json::as_pretty_json(&T::default())).into_bytes();
         let name = name.as_ref();
-        if let Ok(mut path) = current_bin_dir().or(user_app_dir()).or(system_cache_dir()) {
+        if let Ok(mut path) = current_bin_dir()
+            .or_else(|_| user_app_dir())
+            .or_else(|_| system_cache_dir()) {
             path.push(name);
             if let Ok(mut f) = OpenOptions::new()
                 .write(true)
@@ -103,8 +107,9 @@ impl<T> FileHandler<T>
                 .truncate(true)
                 .open(&path) {
                 try!(f.lock_exclusive());
-                try!(f.write_all(&contents));
+                let write_result = f.write_all(&contents);
                 try!(f.unlock());
+                try!(write_result);
                 return Ok(FileHandler {
                     path: path,
                     _ph: PhantomData,
@@ -123,11 +128,9 @@ impl<T> FileHandler<T>
         let mut file = try!(OpenOptions::new().create(false).read(true).open(&self.path));
 
         try!(file.lock_shared());
-        let mut data = String::new();
-        let _ = try!(file.read_to_string(&mut data));
+        let json_result = Json::from_reader(&mut file);
         try!(file.unlock());
-        let json = try!(Json::from_str(&data));
-        Ok(try!(T::decode(&mut Decoder::new(json))))
+        Ok(try!(T::decode(&mut Decoder::new(try!(json_result)))))
     }
 }
 
@@ -141,9 +144,9 @@ impl<T> FileHandler<T>
             try!(OpenOptions::new().write(true).create(true).truncate(true).open(&self.path));
 
         try!(file.lock_exclusive());
-        try!(file.write_all(&contents));
+        let write_result = file.write_all(&contents);
         try!(file.unlock());
-
+        try!(write_result);
 
         Ok(())
     }
@@ -221,40 +224,6 @@ pub fn exe_file_stem() -> Result<OsString, Error> {
     Ok(try!(file_stem.ok_or(not_found_error(&exe_path))).to_os_string())
 }
 
-/// RAII object which removes the [`user_app_dir()`](fn.user_app_dir.html) when an instance is
-/// dropped.
-///
-/// Since the `user_app_dir` is frequently created by tests or examples which use Crust, this is a
-/// convenience object which tries to remove the directory when it is destroyed.
-///
-/// # Examples
-///
-/// ```
-/// use config_file_handler::{FileHandler, ScopedUserAppDirRemover};
-///
-/// {
-///     let _cleaner = ScopedUserAppDirRemover;
-///     let file_handler = FileHandler::new("test.json").unwrap();
-///     // User app dir is possibly created by this call.
-///     let _ = file_handler.write_file(&111u64);
-/// }
-/// // User app dir is now removed since '_cleaner' has gone out of scope.
-/// ```
-pub struct ScopedUserAppDirRemover;
-
-impl ScopedUserAppDirRemover {
-    fn remove_dir(&mut self) {
-        let _ = user_app_dir()
-            .and_then(|user_app_dir| fs::remove_dir_all(user_app_dir).map_err(Error::Io));
-    }
-}
-
-impl Drop for ScopedUserAppDirRemover {
-    fn drop(&mut self) {
-        self.remove_dir();
-    }
-}
-
 fn not_found_error(file_name: &Path) -> io::Error {
     let mut msg: String = From::from("No file name component: ");
     msg.push_str(&file_name.to_string_lossy());
@@ -268,6 +237,42 @@ fn join_exe_file_stem(path: &Path) -> Result<PathBuf, Error> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use error::Error;
+    use std::fs;
+
+    /// RAII object which removes the [`user_app_dir()`](fn.user_app_dir.html) when an instance is
+    /// dropped.
+    ///
+    /// Since the `user_app_dir` is frequently created by tests or examples which use Crust, this is a
+    /// convenience object which tries to remove the directory when it is destroyed.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use config_file_handler::{FileHandler, ScopedUserAppDirRemover};
+    ///
+    /// {
+    ///     let _cleaner = ScopedUserAppDirRemover;
+    ///     let file_handler = FileHandler::new("test.json").unwrap();
+    ///     // User app dir is possibly created by this call.
+    ///     let _ = file_handler.write_file(&111u64);
+    /// }
+    /// // User app dir is now removed since '_cleaner' has gone out of scope.
+    /// ```
+    struct ScopedUserAppDirRemover;
+
+    impl ScopedUserAppDirRemover {
+        fn remove_dir(&mut self) {
+            let _ = user_app_dir()
+                .and_then(|user_app_dir| fs::remove_dir_all(user_app_dir).map_err(Error::Io));
+        }
+    }
+
+    impl Drop for ScopedUserAppDirRemover {
+        fn drop(&mut self) {
+            self.remove_dir();
+        }
+    }
 
     #[test]
     fn read_write_file_test() {
@@ -330,7 +335,7 @@ mod test {
             .collect::<Vec<_>>();
 
         for handle in handles {
-            let _ = handle.join().unwrap();
+            handle.join().unwrap();
         }
 
         let file_handler = FileHandler::new(FILE_NAME).expect("failed accessing file");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@
 
 #![cfg_attr(feature="clippy", feature(plugin))]
 #![cfg_attr(feature="clippy", plugin(clippy))]
-#![cfg_attr(feature="clippy", deny(clippy, clippy))]
+#![cfg_attr(feature="clippy", deny(clippy))]
 #![cfg_attr(feature="clippy", allow(use_debug))]
 
 extern crate fs2;
@@ -55,5 +55,5 @@ mod error;
 mod file_handler;
 
 pub use error::Error;
-pub use file_handler::{FileHandler, ScopedUserAppDirRemover, current_bin_dir, user_app_dir,
-                       system_cache_dir, exe_file_stem, cleanup};
+pub use file_handler::{FileHandler, current_bin_dir, user_app_dir, system_cache_dir,
+                       exe_file_stem, cleanup};


### PR DESCRIPTION
Also fix Clippy warnings and don't export `ScopedUserAppDirRemover` anymore.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/config_file_handler/24)

<!-- Reviewable:end -->
