### PR TITLE
update forum links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 |:---:|:--------:|:-----:|:------:|:----:|
 |[![](http://meritbadge.herokuapp.com/config_file_handler)](https://crates.io/crates/config_file_handler)|[![Build Status](https://travis-ci.org/maidsafe/config_file_handler.svg?branch=master)](https://travis-ci.org/maidsafe/config_file_handler)|[![Build status](https://ci.appveyor.com/api/projects/status/22gb4w9fhvhv3hn4/branch/master?svg=true)](https://ci.appveyor.com/project/MaidSafe-QA/config-file-handler/branch/master)|[![Coverage Status](https://coveralls.io/repos/maidsafe/config_file_handler/badge.svg?branch=master&service=github)](https://coveralls.io/github/maidsafe/config_file_handler?branch=master)|[![Stories in Ready](https://badge.waffle.io/maidsafe/config_file_handler.png?label=ready&title=Ready)](https://waffle.io/maidsafe/config_file_handler)|
 
-| [API Documentation - master branch](http://docs.maidsafe.net/config_file_handler/master) | [MaidSafe website](http://maidsafe.net) | [SAFE Network Forum](https://forum.safenetwork.io) |
+| [API Docs - master branch](http://docs.maidsafe.net/config_file_handler/master) | [MaidSafe website](https://maidsafe.net) | [SAFE Dev Forum](https://forum.safedev.org) | [SAFE Network Forum](https://safenetforum.org) |
 |:------:|:-------:|:-------:|:-------:|
 
 ## Overview


### PR DESCRIPTION
As explained in [this topic](https://safenetforum.org/t/please-update-your-forum-bookmark-to-safenetforum-org/11358), the previous URL is no longer working. The new URL of the SAFE Network Forum is [safenetforum.org](https://safenetforum.org/).

I also added a link to the new [Dev Forum](https://forum.safedev.org/).