### PR TITLE
feat/search-paths: optional for including additional search paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Config File Handler - Change Log
 
+## [0.8.2]
+- Feature to specify additional search paths externally.
+
 ## [0.8.1]
 - change inline style link to reference style link definitions
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ version = "0.8.1"
 
 [dependencies]
 fs2 = "~0.4.2"
+lazy_static = "~0.2.8"
 quick-error = "~1.2.0"
 serde = "~1.0.11"
 serde_json = "~1.0.2"
+unwrap = "~1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "config_file_handler"
 readme = "README.md"
 repository = "https://github.com/maidsafe/config_file_handler"
-version = "0.8.1"
+version = "0.8.2"
 
 [dependencies]
 fs2 = "~0.4.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,9 +26,9 @@
 
 // For explanation of lint checks, run `rustc -W help` or see
 // https://github.com/maidsafe/QA/blob/master/Documentation/Rust%20Lint%20Checks.md
-#![forbid(bad_style, exceeding_bitshifts, mutable_transmutes, no_mangle_const_items,
+#![forbid(exceeding_bitshifts, mutable_transmutes, no_mangle_const_items,
           unknown_crate_types, warnings)]
-#![deny(deprecated, improper_ctypes, missing_docs, non_shorthand_field_patterns,
+#![deny(bad_style, deprecated, improper_ctypes, missing_docs, non_shorthand_field_patterns,
         overflowing_literals, plugin_as_library, private_no_mangle_fns, private_no_mangle_statics,
         stable_features, unconditional_recursion, unknown_lints, unsafe_code, unused,
         unused_allocation, unused_attributes, unused_comparisons, unused_features, unused_parens,
@@ -43,7 +43,11 @@ extern crate serde;
 extern crate serde_json;
 
 #[macro_use]
+extern crate lazy_static;
+#[macro_use]
 extern crate quick_error;
+#[macro_use]
+extern crate unwrap;
 
 mod error;
 mod file_handler;
@@ -51,4 +55,4 @@ mod global_mutex;
 
 pub use error::Error;
 pub use file_handler::{FileHandler, ScopedUserAppDirRemover, cleanup, current_bin_dir,
-                       exe_file_stem, system_cache_dir, user_app_dir};
+                       exe_file_stem, set_additional_search_path, system_cache_dir, user_app_dir};


### PR DESCRIPTION
This is primarily for mobile usage where the default paths used by rust is not enough and the actual path may depend on other factors not known to rust (e.g. Android package name etc.).