### PR TITLE
fix/file-handler: use fallback in exe_file_stem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Config File Handler - Change Log
 
+## [0.8.3]
+- `exe_file_stem` falls back to a default value in case of error
+
 ## [0.8.2]
 - Feature to specify additional search paths externally.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 name = "config_file_handler"
 readme = "README.md"
 repository = "https://github.com/maidsafe/config_file_handler"
-version = "0.8.2"
+version = "0.8.3"
 
 [dependencies]
 fs2 = "~0.4.2"

--- a/src/file_handler.rs
+++ b/src/file_handler.rs
@@ -524,13 +524,16 @@ pub fn system_cache_dir() -> Result<PathBuf, Error> {
 /// The file name of the currently-running binary without any suffix or extension.  For example, if
 /// the binary is "C:\\Abc.exe" this function will return `Ok("Abc")`.
 pub fn exe_file_stem() -> Result<OsString, Error> {
-    let exe_path = env::current_exe()?;
-    let file_stem = exe_path.file_stem();
-    Ok(
-        file_stem
-            .ok_or_else(|| not_found_error(&exe_path))?
-            .to_os_string(),
-    )
+    if let Ok(exe_path) = env::current_exe() {
+        let file_stem = exe_path.file_stem();
+        Ok(
+            file_stem
+                .ok_or_else(|| not_found_error(&exe_path))?
+                .to_os_string(),
+        )
+    } else {
+        Ok(From::from("default"))
+    }
 }
 
 /// RAII object which removes the [`user_app_dir()`](fn.user_app_dir.html) when an instance is


### PR DESCRIPTION
If the exe file stem cannot be determined, fall back to "default". Fixes issues on some mobile platforms.