### PR TITLE
Switch to musl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,7 @@ cache:
 before_script:
   - curl -sSL https://github.com/maidsafe/QA/raw/master/travis/cargo_install.sh > cargo_install.sh
   - bash cargo_install.sh cargo-prune;
-  - rustup component add rustfmt
-  - rustup component add clippy
+  - rustup component add rustfmt clippy
 script:
   - set -x;
     cargo fmt -- --check &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ before_script:
 script:
   - set -x;
     cargo fmt -- --check &&
-    cargo test --target $TARGET --release --verbose &&
     cargo clippy --target $TARGET &&
-    cargo clippy --target $TARGET --profile test
+    cargo clippy --target $TARGET --profile test &&
+    cargo test --target $TARGET --release --verbose
 before_cache:
  - cargo prune

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ env:
   global:
     - PATH=$PATH:$HOME/.cargo/bin
     - RUST_BACKTRACE=1
+    - TARGET=x86_64-unknown-linux-musl
 os:
   - linux
   - osx
@@ -17,12 +18,13 @@ cache:
 before_script:
   - curl -sSL https://github.com/maidsafe/QA/raw/master/travis/cargo_install.sh > cargo_install.sh
   - bash cargo_install.sh cargo-prune;
+  - rustup target add $TARGET
   - rustup component add rustfmt clippy
 script:
   - set -x;
     cargo fmt -- --check &&
-    cargo test --release --verbose &&
-    cargo clippy &&
-    cargo clippy --profile test
+    cargo test --target $TARGET --release --verbose &&
+    cargo clippy --target $TARGET &&
+    cargo clippy --target $TARGET --profile test
 before_cache:
  - cargo prune

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ before_script:
 script:
   - set -x;
     cargo fmt -- --check &&
-    cargo clippy --target $TARGET &&
-    cargo clippy --target $TARGET --profile test &&
-    cargo test --target $TARGET --release --verbose
+    cargo clippy --verbose --target $TARGET &&
+    cargo clippy --verbose --target $TARGET --profile test &&
+    cargo test --verbose --target $TARGET --release
 before_cache:
  - cargo prune

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,11 @@ env:
   global:
     - PATH=$PATH:$HOME/.cargo/bin
     - RUST_BACKTRACE=1
-    - TARGET=x86_64-unknown-linux-musl
-os:
-  - linux
-  - osx
+matrix:
+  include:
+    - os: linux
+      env: TARGET=x86_64-unknown-linux-musl
+    - os: osx
 language: rust
 rust:
   - stable
@@ -18,13 +19,18 @@ cache:
 before_script:
   - curl -sSL https://github.com/maidsafe/QA/raw/master/travis/cargo_install.sh > cargo_install.sh
   - bash cargo_install.sh cargo-prune;
-  - rustup target add $TARGET
+  - if [[ -n "$TARGET" ]]; then
+      rustup target add $TARGET;
+    fi
   - rustup component add rustfmt clippy
 script:
   - set -x;
+    if [[ -n "$TARGET" ]]; then
+      TARGET_FLAG="--target $TARGET";
+    fi &&
     cargo fmt -- --check &&
-    cargo check --verbose --all-targets --target $TARGET &&
-    cargo clippy --verbose --all-targets --target $TARGET &&
-    cargo test --verbose --release --target $TARGET
+    cargo check --verbose --all-targets $TARGET_FLAG &&
+    cargo clippy --verbose --all-targets $TARGET_FLAG &&
+    cargo test --verbose --release $TARGET_FLAG
 before_cache:
  - cargo prune

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_script:
 script:
   - set -x;
     cargo fmt -- --check &&
+    cargo check --verbose --all-targets --target $TARGET &&
     cargo clippy --verbose --all-targets --target $TARGET &&
     cargo test --verbose --release --target $TARGET
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,7 @@ before_script:
 script:
   - set -x;
     cargo fmt -- --check &&
-    cargo clippy --verbose --target $TARGET &&
-    cargo clippy --verbose --target $TARGET --profile test &&
-    cargo test --verbose --target $TARGET --release
+    cargo clippy --verbose --all-targets --target $TARGET &&
+    cargo test --verbose --release --target $TARGET
 before_cache:
  - cargo prune


### PR DESCRIPTION
Use musl in CI on Linux and OS X to allow reproducible build on a wider variety of platforms.
Also perform some minor cleanups in the travis config file.